### PR TITLE
Replace previous documented print orientation methods name

### DIFF
--- a/en/printed/landscape.md
+++ b/en/printed/landscape.md
@@ -3,7 +3,7 @@
 ## **Function Prototype**
 
 ```php
-setPrintedLandscape(): self
+setLandscape(): self
 ```
 
 ## **Example**
@@ -13,6 +13,6 @@ $config = ['path' =>'./tests'];
 $excel = new \Vtiful\Kernel\Excel($config);
 
 $excel->fileName('printed_landscape.xlsx','sheet1')
-    ->setPrintedLandscape() // Set the printing direction to landscape
+    ->setLandscape() // Set the printing direction to landscape
     ->output();
 ```

--- a/en/printed/portrait.md
+++ b/en/printed/portrait.md
@@ -3,7 +3,7 @@
 ## **Function Prototype**
 
 ```php
-setPrintedPortrait(): self
+setPortrait(): self
 ```
 
 ## **Example**
@@ -13,6 +13,6 @@ $config = ['path' =>'./tests'];
 $excel = new \Vtiful\Kernel\Excel($config);
 
 $excel->fileName('printed_portrait.xlsx','sheet1')
-    ->setPrintedPortrait() // Set the printing direction to portrait
+    ->setPortrait() // Set the printing direction to portrait
     ->output();
 ```

--- a/zh-cn/printed/landscape.md
+++ b/zh-cn/printed/landscape.md
@@ -3,7 +3,7 @@
 ## **函数原型**
 
 ```php
-setPrintedLandscape(): self
+setLandscape(): self
 ```
 
 ## **实例**
@@ -13,6 +13,6 @@ $config = ['path' => './tests'];
 $excel  = new \Vtiful\Kernel\Excel($config);
 
 $excel->fileName('printed_landscape.xlsx', 'sheet1')
-    ->setPrintedLandscape() // 设置打印方向为横向
+    ->setLandscape() // 设置打印方向为横向
     ->output();
 ```

--- a/zh-cn/printed/portrait.md
+++ b/zh-cn/printed/portrait.md
@@ -3,7 +3,7 @@
 ## **函数原型**
 
 ```php
-setPrintedPortrait(): self
+setPortrait(): self
 ```
 
 ## **实例**
@@ -13,6 +13,6 @@ $config = ['path' => './tests'];
 $excel  = new \Vtiful\Kernel\Excel($config);
 
 $excel->fileName('printed_portrait.xlsx', 'sheet1')
-    ->setPrintedPortrait() // 设置打印方向为纵向
+    ->setPortrait() // 设置打印方向为纵向
     ->output();
 ```


### PR DESCRIPTION
`setPrintedLandscape`and `setPrintedPortrait` are still documented with their previous names. Replaced them to avoid miscomprehension about non existing methods when defining print orientations.